### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/resume.js
+++ b/resume.js
@@ -117,10 +117,19 @@ function populateTaskList() {
 
       const entry = document.createElement('div');
       entry.classList.add('task-entry');
-      entry.innerHTML = `
-        <span>${title}</span>
-        <button onclick="closeWindow('${id}'); populateTaskList();">❌ Close</button>
-      `;
+      
+      const span = document.createElement('span');
+      span.textContent = title;
+      entry.appendChild(span);
+      
+      const button = document.createElement('button');
+      button.textContent = '❌ Close';
+      button.onclick = () => {
+        closeWindow(id);
+        populateTaskList();
+      };
+      entry.appendChild(button);
+      
       list.appendChild(entry);
     }
   });


### PR DESCRIPTION
Potential fix for [https://github.com/a-meg-s/a-meg-s.github.io/security/code-scanning/1](https://github.com/a-meg-s/a-meg-s.github.io/security/code-scanning/1)

To fix the issue, we need to ensure that any untrusted data is properly escaped before being inserted into the DOM as HTML. Instead of using `innerHTML` to directly insert the `title` into the DOM, we can use `textContent` to safely insert the text without interpreting it as HTML. This approach prevents any potential XSS attacks by treating the data as plain text.

The fix involves:
1. Creating the `span` and `button` elements programmatically instead of using a template literal.
2. Setting the `textContent` of the `span` element to the `title` to ensure proper escaping.
3. Appending these elements to the `entry` element.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
